### PR TITLE
Allow clients to pass in already-serialized documents

### DIFF
--- a/qouch.js
+++ b/qouch.js
@@ -168,7 +168,9 @@ Qouch.prototype.request = function(method, path, body) {
     },
     agent: this.httpAgent
   };
-  if (body) opts.body = [ JSON.stringify(body) ];
+  if (body) {
+    opts.body = [ typeof body === 'string' ? body : JSON.stringify(body) ];
+  };
 
   return http.request(opts)
   .then(function(res) {


### PR DESCRIPTION
It's possible that the object being passed along with the request has already been serialized. This isn't the case in any of our existing projects but I've noticed it while working on [this](https://github.com/jamesallardice/kudu).

As far as I can tell this won't affect any of our other use cases as we seem to always pass in an object currently and almost certainly don't rely upon the JSON stringification of a string.
